### PR TITLE
Makes possible to setup SO_REUSEPORT option before binding to address

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,16 +1,22 @@
 sbin_PROGRAMS = privbind
 pkglib_LTLIBRARIES = privbind.la
 noinst_PROGRAMS = testbind
+noinst_LTLIBRARIES = list.la
 
 doc_DATA = README
 man_MANS = privbind.1
 EXTRA_DIST = $(man_MANS)
 
-privbind_SOURCES = main.c
-noinst_HEADERS = ipc.h stub.h
+list_la_SOURCES = list.c
+list_la_LDFLAGS=-ldl -module -avoid-version 
+LDADD = list.la
 
-privbind_la_SOURCES = libprivbind.c
-privbind_la_LDFLAGS=-ldl -module -avoid-version
+privbind_SOURCES = main.c
+noinst_HEADERS = ipc.h stub.h list.h
+
+privbind_la_SOURCES = libprivbind.c 
+privbind_la_LIBADD = list.la
+privbind_la_LDFLAGS=-ldl -module -avoid-version 
 
 testbind_SOURCES = test.c
 testbind_LDADD = -lpthread

--- a/libprivbind.c
+++ b/libprivbind.c
@@ -33,11 +33,11 @@
 #include <stdio.h>
 
 #include "stub.h"
-
 #include "ipc.h"
+#include "list.h"
 
 static int master_quit=0; /* Whether helper process quit - assume false at first */
-static int reuse_port=-1; /* if we should setup SO_REUSEPORT socket option */
+static intlist_t reuse_ports={.count = -1}; /* for which ports we should setup SO_REUSEPORT socket option */
 
 FUNCREDIR1( close, int, int );
 FUNCREDIR3( bind, int, int, const struct sockaddr *, socklen_t );
@@ -99,16 +99,32 @@ static int acquire_lock( int acquire )
 int bind( int sockfd, const struct sockaddr *my_addr, socklen_t addrlen)
 {
 #ifdef SO_REUSEPORT
-   /**/
-   if (reuse_port < 0){
-     char *env_reuse = getenv("PRIVBIND_REUSE_PORT");
-     reuse_port = (env_reuse != NULL && strlen(env_reuse) == 1 && env_reuse[0] == '1');
+   // parse environment property (just once)
+   if (reuse_ports.count < 0){
+     char *env_reuse = getenv("PRIVBIND_REUSE_PORTS");
+     if (env_reuse == NULL){
+       reuse_ports.count = 0;
+     }else{
+       if (parselist(env_reuse, &reuse_ports) != 0){
+         reuse_ports.count = -1;
+         return -1;
+       }
+     }
    }
-   if (reuse_port){
-     int optval = 1;
-     int retval = setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
-     if (retval != 0)
-       return retval;
+   
+   // get bind port
+   int port = -1;
+   if (my_addr->sa_family==AF_INET)
+      port = (int) ntohs(((struct sockaddr_in *) my_addr)->sin_port);
+   else if (my_addr->sa_family==AF_INET6)
+      port = (int) ntohs(((struct sockaddr_in6 *) my_addr)->sin6_port);
+   
+   // check if we should setup SO_REUSEPORT for this port
+   if (port != -1 && is_in_list(&reuse_ports, port)){
+      int optval = 1;
+      int retval = setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+      if (retval != 0)
+        return retval;
    }
 #endif
   

--- a/libprivbind.c
+++ b/libprivbind.c
@@ -105,7 +105,7 @@ int bind( int sockfd, const struct sockaddr *my_addr, socklen_t addrlen)
      if (env_reuse == NULL){
        reuse_ports.count = 0;
      }else{
-       if (parselist(env_reuse, &reuse_ports) != 0){
+       if (parselist(env_reuse, &reuse_ports, 1, 65535) != 0){
          reuse_ports.count = -1;
          return -1;
        }

--- a/libprivbind.c
+++ b/libprivbind.c
@@ -102,11 +102,13 @@ int bind( int sockfd, const struct sockaddr *my_addr, socklen_t addrlen)
    /**/
    if (reuse_port < 0){
      char *env_reuse = getenv("PRIVBIND_REUSE_PORT");
-     reuse_port = env_reuse != NULL && strlen(env_reuse) == 1 && env_reuse[0] == '1';
+     reuse_port = (env_reuse != NULL && strlen(env_reuse) == 1 && env_reuse[0] == '1');
    }
    if (reuse_port){
      int optval = 1;
-     setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+     int retval = setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+     if (retval != 0)
+       return retval;
    }
 #endif
   

--- a/list.c
+++ b/list.c
@@ -22,10 +22,15 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <limits.h>
 
 #include "list.h"
 
-int parselist(char *str, intlist_t * list) {
+int parseintlist(char *str, intlist_t * list) {
+  return parselist(str, list, INT_MIN, INT_MAX);
+}
+
+int parselist(char *str, intlist_t * list, int min_value, int max_value) {
 
   int len = strlen(str);
   char *tmp = malloc(len + 1);
@@ -44,7 +49,7 @@ int parselist(char *str, intlist_t * list) {
     }
   }
   list->values = malloc(list->count * sizeof (int));
-  if (tmp == NULL) {
+  if (list->values == NULL) {
     fprintf(stderr, "privbind: Error parsing list - out of memory\n");
     goto fail;
   }
@@ -56,14 +61,15 @@ int parselist(char *str, intlist_t * list) {
       char *ptr;
       long int l = strtol(num_start, &ptr, 10);
       if (num_start == ptr || *ptr != 0) {
-        fprintf(stderr, "privbind: Can't parse list of numbers\n");
+        fprintf(stderr, "privbind: Can't parse list of numbers. It is a number list?\n");
+        goto fail_result;
+      }
+      if ( l < ((long int) min_value) || l > ((long int) max_value) ) {
+        fprintf(stderr, "privbind: Can't parse list of numbers. Number %d is out of range <%d, %d>.\n", 
+                l, min_value, max_value);
         goto fail_result;
       }
       list->values[i] = (int) l;
-      if (((long int) list->values[i]) != l) {
-        fprintf(stderr, "privbind: Can't parse list of numbers\n");
-        goto fail_result;
-      }
       i++;
       num_start = tmp + pos + 1;
     }

--- a/list.c
+++ b/list.c
@@ -1,0 +1,88 @@
+/*
+ * privbind - allow unpriviledged apps to bind to priviledged ports
+ * Copyright (C) 2015 Lukáš karas <karas@avast.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "list.h"
+
+int parselist(char *str, intlist_t * list) {
+
+  int len = strlen(str);
+  char *tmp = malloc(len + 1);
+  if (tmp == NULL) {
+    fprintf(stderr, "privbind: Error parsing list - out of memory\n");
+    return -1;
+  }
+  memcpy(tmp, str, len + 1);
+
+  // count of numbers, replace comma character with zero byte
+  list->count = 0;
+  for (int pos = 0; pos <= len; pos++) {
+    if (tmp[pos] == CHAR_COMMA || tmp[pos] == 0) {
+      list->count++;
+      tmp[pos] = 0;
+    }
+  }
+  list->values = malloc(list->count * sizeof (int));
+  if (tmp == NULL) {
+    fprintf(stderr, "privbind: Error parsing list - out of memory\n");
+    goto fail;
+  }
+  // convert numbers in list
+  char *num_start = tmp;
+  int i = 0;
+  for (int pos = 0; pos <= len; pos++) {
+    if (tmp[pos] == 0) {
+      char *ptr;
+      long int l = strtol(num_start, &ptr, 10);
+      if (num_start == ptr || *ptr != 0) {
+        fprintf(stderr, "privbind: Can't parse list of numbers\n");
+        goto fail_result;
+      }
+      list->values[i] = (int) l;
+      if (((long int) list->values[i]) != l) {
+        fprintf(stderr, "privbind: Can't parse list of numbers\n");
+        goto fail_result;
+      }
+      i++;
+      num_start = tmp + pos + 1;
+    }
+  }
+  free(tmp);
+  return 0;
+
+fail_result: // fail, result is allocated already
+  free(list->values);
+fail: // fail, tmp is allocated already
+  free(tmp);
+  return -1;
+}
+
+bool is_in_list(const intlist_t * list, int value) {
+  for (int i = 0; i < list->count; i++) {
+    if (value == list->values[i]) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/list.h
+++ b/list.h
@@ -1,0 +1,59 @@
+/*
+ * privbind - allow unpriviledged apps to bind to priviledged ports
+ * Copyright (C) 2015 Lukáš karas <karas@avast.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include <stdbool.h>
+
+#ifndef LISTPARSER_H
+#define	LISTPARSER_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#define CHAR_COMMA ','
+  
+typedef struct
+{
+    int  count;
+    int* values;
+}
+intlist_t;
+
+/**
+ * 
+ * @param str - zero ended string contains comma separated numbers
+ * @param list - 
+ * @return non-zero if some error occurs
+ */
+int parselist(char *str, intlist_t * list);
+
+/**
+ * @param list
+ * @param value
+ * @return true(1) if list contains given value
+ */
+bool is_in_list(const intlist_t * list, int value);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* LISTPARSER_H */
+

--- a/list.h
+++ b/list.h
@@ -20,8 +20,8 @@
 
 #include <stdbool.h>
 
-#ifndef LISTPARSER_H
-#define	LISTPARSER_H
+#ifndef LIST_H
+#define	LIST_H
 
 #ifdef	__cplusplus
 extern "C" {
@@ -37,12 +37,25 @@ typedef struct
 intlist_t;
 
 /**
+ * Parse string "str" with comma separated list of numbers and fills up 
+ * list structure.
  * 
  * @param str - zero ended string contains comma separated numbers
  * @param list - 
  * @return non-zero if some error occurs
  */
-int parselist(char *str, intlist_t * list);
+int parseintlist(char *str, intlist_t * list);
+
+/**
+ * Same as previos. Numbers in list have to be in given range (inclusive).
+ * 
+ * @param str - zero ended string contains comma separated numbers
+ * @param list
+ * @param min_value - minimum value (inclusive)
+ * @param max_value - maximum value (inclusive)
+ * @return 
+ */
+int parselist(char *str, intlist_t * list, int min_value, int max_value);
 
 /**
  * @param list
@@ -55,5 +68,5 @@ bool is_in_list(const intlist_t * list, int value);
 }
 #endif
 
-#endif	/* LISTPARSER_H */
+#endif	/* LIST_H */
 

--- a/main.c
+++ b/main.c
@@ -72,6 +72,9 @@ void help( const char *progname )
         "     the helper proccess exits.\n"
         "-l - Explicitly specify the path to the library to use for preload\n"
         "     This option is for debug use only.\n"
+#ifdef SO_REUSEPORT
+        "-r - setup SO_REUSEPORT option to all sockets before binding it to address\n"
+#endif
 #if DEBUG_TESTING
         "-w - Delay each bind by num seconds. Only useful for internal privbind\n"
         "     testing.\n"
@@ -93,7 +96,7 @@ int parse_cmdline( int argc, char *argv[] )
     
     int opt;
 
-    while( (opt=getopt(argc, argv, "+n:u:g:Gl:w:h" ))!=-1 ) {
+    while( (opt=getopt(argc, argv, "+n:u:g:Gl:w:h:r" ))!=-1 ) {
         switch(opt) {
         case 'n':
             options.numbinds=atoi(optarg);
@@ -170,6 +173,11 @@ int parse_cmdline( int argc, char *argv[] )
 #if DEBUG_TESTING
         case 'w':
             options.wait=atoi(optarg);
+            break;
+#endif
+#ifdef SO_REUSEPORT
+        case 'r':
+            setenv("PRIVBIND_REUSE_PORT", "1", FALSE );
             break;
 #endif
         case 'h':

--- a/main.c
+++ b/main.c
@@ -205,7 +205,7 @@ int parse_cmdline( int argc, char *argv[] )
 #endif
 #ifdef SO_REUSEPORT
         case 'r':
-            if (parselist(optarg, &l) != 0){
+            if (parselist(optarg, &l, 1, 65535) != 0){
                 fprintf(stderr, "Can't parse list of ports\n");
                 exit(1);
             }


### PR DESCRIPTION
With these patches, it is possible to define comma separated list of ports for those should be setup SO_REUSEPORT option before bind. This functionality moves privbind to more universal wrapper.

It is possible to run more servers binded to same address with this option (see man 7 socket). It can be useful for programs that don't support reused ports (java based servers) but it is safe to do it. 

Technical note:
Privbind setup environment variable PRIVBIND_REUSE_PORTS with list of ports that should be shared (reused), in bind(...) function libprivbind then check this list and setup SO_REUSEPORT when needed...
